### PR TITLE
Track guestbook entry locations

### DIFF
--- a/components/guestbook-grid.tsx
+++ b/components/guestbook-grid.tsx
@@ -40,6 +40,7 @@ interface GuestbookEntryDisplay {
   message: string
   color: string
   name: string
+  location?: string
   drawing?: string
   drawingCommands?: DrawingCommand[]
   createdAt?: string | Date
@@ -338,6 +339,7 @@ export default function GuestbookGrid() {
             message: entry.message,
             color: entry.color,
             name: entry.name,
+            location: entry.location ?? undefined,
             drawing: entry.drawingUrl || undefined,
             drawingCommands: (entry.drawingCommands as DrawingCommand[]) || undefined,
             createdAt: (entry as any).createdAt,
@@ -418,6 +420,7 @@ export default function GuestbookGrid() {
           message: savedEntry.message,
           color: savedEntry.color,
           name: savedEntry.name,
+          location: savedEntry.location ?? undefined,
           drawing: savedEntry.drawingUrl || undefined,
           drawingCommands: savedEntry.drawingCommands as DrawingCommand[] || undefined,
         }

--- a/drizzle/0000_add_location_to_guestbook_entries.sql
+++ b/drizzle/0000_add_location_to_guestbook_entries.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "guestbook_entries" ADD COLUMN "location" varchar(150);

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,104 @@
+{
+  "id": "a4e33267-e8be-4798-9bcc-315de3f75495",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.guestbook_entries": {
+      "name": "guestbook_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "grid_index": {
+          "name": "grid_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Anonymous'"
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drawing_url": {
+          "name": "drawing_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drawing_commands": {
+          "name": "drawing_commands",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "guestbook_entries_grid_index_unique": {
+          "name": "guestbook_entries_grid_index_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "grid_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,5 +1,13 @@
 {
   "version": "7",
   "dialect": "postgresql",
-  "entries": []
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1763128504000,
+      "tag": "0000_add_location_to_guestbook_entries",
+      "breakpoints": false
+    }
+  ]
 }

--- a/lib/db/actions.ts
+++ b/lib/db/actions.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { eq } from 'drizzle-orm'
+import { headers } from 'next/headers'
 import { db } from './db'
 import { guestbookEntries, type NewGuestbookEntry, type GuestbookEntry } from './schema'
 
@@ -21,9 +22,17 @@ export async function createGuestbookEntry(entry: Omit<NewGuestbookEntry, 'id' |
       throw new Error('Name is required')
     }
 
+    const headerList = headers()
+    const locationParts = [
+      headerList.get('x-vercel-ip-city'),
+      headerList.get('x-vercel-ip-country-region'),
+      headerList.get('x-vercel-ip-country'),
+    ].filter((part): part is string => Boolean(part && part.trim()))
+    const location = locationParts.length > 0 ? locationParts.join(', ') : null
+
     const [newEntry] = await db
       .insert(guestbookEntries)
-      .values({ ...entry, name: trimmedName })
+      .values({ ...entry, name: trimmedName, location })
       .returning()
     return newEntry
   } catch (error) {

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -6,6 +6,7 @@ export const guestbookEntries = pgTable('guestbook_entries', {
   message: text('message').notNull(),
   color: varchar('color', { length: 7 }).notNull(),
   name: varchar('name', { length: 100 }).notNull().default('Anonymous'),
+  location: varchar('location', { length: 150 }),
   drawingUrl: text('drawing_url'),
   drawingCommands: jsonb('drawing_commands'),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),


### PR DESCRIPTION
## Summary
- add an optional location column to guestbook entries and include it in the schema snapshot
- populate the location from Vercel geolocation headers when creating entries and keep the client state in sync
- add a migration to add the new column to existing databases

## Testing
- pnpm lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917339079a483309bcee63ceb20d058)